### PR TITLE
add a trailing space for better pattern-matching on channel names

### DIFF
--- a/manifests/channel.pp
+++ b/manifests/channel.pp
@@ -73,7 +73,7 @@ define spacewalk::channel(
     exec { $title:
       command => "spacewalk-channel ${channel_option} -c ${channel} -u ${username} -p ${password}",
       path    => ['/usr/bin', '/usr/sbin', '/bin', ],
-      unless  => "yum -C repolist enabled 2>/dev/null | grep -qw ${channel}",
+      unless  => "yum -C repolist enabled 2>/dev/null | grep -qw \'${channel} \'",
     }
 
     if $channel_key_id != '' and $channel_key_uri != '' {


### PR DESCRIPTION
So that channels named "centos6-x86_64-spacewalk" can get added to a host when it's already subscribed to "centos6-x86_64-spacewalk-client".
